### PR TITLE
修复 Kernel Stack 回收错误

### DIFF
--- a/os/Makefile
+++ b/os/Makefile
@@ -51,7 +51,6 @@ fs-img: $(APPS)
 	@cd ../easy-fs-fuse && cargo run --release -- -s ../user/src/bin/ -t ../user/target/riscv64gc-unknown-none-elf/release/
 
 kernel:
-	@make -C ../user build TEST=$(TEST) CHAPTER=$(CHAPTER) BASE=$(BASE)
 	@echo Platform: $(BOARD)
 	@cargo build --release
 
@@ -86,7 +85,10 @@ debug: build
 
 
 gdbserver: build
-	@qemu-system-riscv64 -M 128m -machine virt -nographic -bios $(BOOTLOADER) -device loader,file=$(KERNEL_BIN),addr=$(KERNEL_ENTRY_PA) -s -S
+	@qemu-system-riscv64 -M 128m -machine virt -nographic -bios $(BOOTLOADER) -device loader,file=$(KERNEL_BIN),addr=$(KERNEL_ENTRY_PA) \
+	-drive file=$(FS_IMG),if=none,format=raw,id=x0 \
+        -device virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0 \
+	-s -S
 
 gdbclient:
 	@riscv64-unknown-elf-gdb -ex 'file $(KERNEL_ELF)' -ex 'set arch riscv:rv64' -ex 'target remote localhost:1234'

--- a/os/src/mm/memory_set.rs
+++ b/os/src/mm/memory_set.rs
@@ -79,6 +79,9 @@ impl MemorySet {
         {
             area.unmap(&mut self.page_table);
             self.areas.remove(idx);
+            unsafe {
+                asm!("sfence.vma");
+            }
         }
     }
     /// Add a new MapArea into this MemorySet.

--- a/os/src/trap/mod.rs
+++ b/os/src/trap/mod.rs
@@ -36,8 +36,11 @@ pub fn init() {
 }
 /// set trap entry for traps happen in kernel(supervisor) mode
 fn set_kernel_trap_entry() {
+    extern "C" {
+        fn __trap_from_kernel();
+    }
     unsafe {
-        stvec::write(trap_from_kernel as usize, TrapMode::Direct);
+        stvec::write(__trap_from_kernel as usize, TrapMode::Direct);
     }
 }
 /// set trap entry for traps happen in user mode

--- a/os/src/trap/trap.S
+++ b/os/src/trap/trap.S
@@ -67,3 +67,20 @@ __restore:
     # back to user stack
     ld sp, 2*8(sp)
     sret
+
+    .section .data
+    # emergency stack for kernel trap
+    # in order to print trap info even if the kernel stack is corrupted.
+__emergency:
+    .align 4
+    .space 1024 * 4
+__emergency_end:
+
+
+    .section .text
+    .globl __trap_from_kernel
+    # 2^2=4 bytes aligned for stvec
+    .align 2
+__trap_from_kernel:
+    la sp, __emergency_end
+    j trap_from_kernel    


### PR DESCRIPTION
在完成 CH8 作业时，我遇到了以下问题：单独运行测例程序能够正常运行，但是运行 `ch8b_usertest` 或 `ch8_usertest` 时就有概率发生 kernel panic 报错，如下所示：

``` plain
[kernel] Panicked at src/trap/mod.rs:143 a trap Exception(StorePageFault) from kernel!
[kernel] Panicked at src/task/processor.rs:119 called `Option::unwrap()` on a `None` value
[kernel] Panicked at src/task/processor.rs:119 called `Option::unwrap()` on a `None` value
[kernel] Panicked at src/task/processor.rs:119 called `Option::unwrap()` on a `None` value
...
```

经过检查，我发现 ch8 代码中有如下缺陷：

1. 通过打印 `sepc/stval` 等寄存器的信息，我发现上面汇报 Page Fault 时的内存地址和触发代码为内核栈内的有效空间以及 `trap_from_kernel()` 函数。结合汇编代码我推断，由于 kernel trap handler 复用了当前正在使用的 kernel stack，因此当 stack 发生异常时将无法正常执行 trap handler。对此我修改了 kernel trap handler，在进入前修改 `sp` 至预留的内存空间中。
2. 在修复上述问题后，我发现出错原因在于回收了当前正在使用的 kernel stack。进一步分析发现当线程退出 `tid == 0` 时 ，该进程会[回收其所有线程的资源](https://github.com/LearningOS/rCore-Tutorial-Code-2023S/blob/6c487dfd445cd4dc473278ad8c25ac603ce0560f/os/src/task/mod.rs#L155)，也包括内核栈。从而在执行后续代码（包括[回收 Kernel Stack  编号](https://github.com/LearningOS/rCore-Tutorial-Code-2023S/blob/6c487dfd445cd4dc473278ad8c25ac603ce0560f/os/src/task/id.rs#L104) 以及后续的[切换任务上下文](https://github.com/LearningOS/rCore-Tutorial-Code-2023S/blob/6c487dfd445cd4dc473278ad8c25ac603ce0560f/os/src/task/mod.rs#L159)）发生 PageFault。而这一错误之所以不会经常触发则可能是因为 TLB 中仍然保留内核栈的地址转换信息，因此在删除地址段后加入 `sfence.vma` 即可稳定触发这一 bug。
    因此，为了避免当前线程资源被回收，我在 `TaskManager` 中保留了一份当前线程的引用，以确保该线程资源不会被回收。（也许放在别的地方更好？欢迎老师助教指教）

另外，我在调试过程中还发现另外一些小问题：

1. 在 CH6 之后，kernel 的编译不再依赖于用户态程序，因此 `Makefile` 中可以删除对应任务，节省编译时间。
2. `gdb` 的运行命令并未更新至包含 fs  的版本。

